### PR TITLE
Remove Delete Permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Release Information 
 
-- **Version**: 1.0.0 
+- **Version**: 1.0.1
 - **Certified**: Yes 
 - **Publisher**: Fortinet 
 - **Compatible Version**: FortiSOAR 7.4.3 and later 
+- [Release Notes](./release_notes.md)
  
 
  # Overview 

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "platformUtilities",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "fsrMinCompatibility": "7.4.3",
     "type": "solutionpack",
     "local": true,
@@ -10,7 +10,7 @@
     "publisher": "Fortinet",
     "certified": "true",
     "description": "The Platform Utilities solution pack includes the essential 'Key Store' module needed for various solution packs to function.",
-    "help": "https://github.com/fortinet-fortisoar/solution-pack-platform-utilities/blob/release/1.0.0/README.md",
+    "help": "https://github.com/fortinet-fortisoar/solution-pack-platform-utilities/blob/release/1.0.1/README.md",
     "category": [
         "FortiSOAR Essentials"
     ],

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,3 @@
+# What's New
+
+- Removed delete permission for the "Key Store" module to prevent accidental deletion of the keystore records

--- a/roles/Full App Permissions-21d7a7c6-9d68-438f-b732-e8950c5f745b.json
+++ b/roles/Full App Permissions-21d7a7c6-9d68-438f-b732-e8950c5f745b.json
@@ -11,7 +11,7 @@
             "canExecute": true,
             "canRead": true,
             "canUpdate": true,
-            "canDelete": true,
+            "canDelete": false,
             "fieldPermissions": [],
             "module": "keys"
         }


### PR DESCRIPTION
- Updated version from 1.0.0 to 1.0.1
- Added release notes

### Mantis#1089826
- Validated that the delete permission for the Key Stores module has been removed from the "Full Add Permission" role